### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php": "^5.6 || ^7.0",
         "symfony/console": "^3.1",
-        "phpunit/phpunit": "^5.4",
+        "phpunit/phpunit": "^5.7",
         "psr/log": "^1.0",
         "gpupo/cache": "*",
         "gpupo/common": "^1.7.0",

--- a/tests/Documentor/Docblock.php
+++ b/tests/Documentor/Docblock.php
@@ -114,7 +114,7 @@ class Docblock
             $tc = $conf['testcase'];
         }
 
-        $data['testcase'] = empty($tc) ? '\PHPUnit_Framework_TestCase' : $tc;
+        $data['testcase'] = empty($tc) ? 'TestCase' : $tc;
 
         if (false === strpos($data['testcase'], 'TestCaseAbstract')) {
             $data['testcase'] .= ' as TestCaseAbstract';

--- a/tests/TestCaseAbstract.php
+++ b/tests/TestCaseAbstract.php
@@ -23,8 +23,9 @@ use Gpupo\Tests\CommonSdk\Traits\ProxyTrait;
 use Monolog\Handler\ErrorLogHandler;
 use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
+use PHPUnit\Framework\TestCase;
 
-abstract class TestCaseAbstract extends \PHPUnit_Framework_TestCase
+abstract class TestCaseAbstract extends TestCase
 {
     use LoggerTrait;
     use ProxyTrait;


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

I just need to bump PHPUnit version to [`^5.7`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-5.7.md#570---2016-12-02), that support this namespace.